### PR TITLE
AV-677: broken link notification email

### DIFF
--- a/ckanext/archiver/commands.py
+++ b/ckanext/archiver/commands.py
@@ -84,6 +84,9 @@ class Archiver(CkanCommand):
            - For when you reduce the ckanext-archiver.max_content_length and
              want to delete archived files that are now above the threshold,
              and stop referring to these files in the Archival table of the db.
+
+        paster archiver send_broken_link_notification
+            - Sends an email notification to datasets maintainers about broken links in their resources
     '''
     # TODO
     #    paster archiver clean-files
@@ -659,7 +662,6 @@ class Archiver(CkanCommand):
 
         resources_with_broken = (model.Session.query(Archival, model.Package, model.Resource)
             .filter(Archival.is_broken == True) # noqa
-            .filter(Archival.first_failure < todayMinus4)
             .join(model.Package, Archival.package_id == model.Package.id)
             .filter(model.Package.state == 'active')
             .join(model.Resource, Archival.resource_id == model.Resource.id)
@@ -671,6 +673,7 @@ class Archiver(CkanCommand):
         for resource in resources_with_broken.all():
             # TODO: here we should check if it is 403 error
             # Currently we check if it is broken
+            print resource[2].url
             if Status.is_status_broken(resource[0].status_id):
                 maintainer = resource[1].maintainer
 

--- a/ckanext/archiver/email_templates/broken_links_notification.py
+++ b/ckanext/archiver/email_templates/broken_links_notification.py
@@ -1,0 +1,54 @@
+from pylons import config
+
+"""
+    A template file for resource broken link notification emails.
+"""
+
+
+def message(itemList):
+    items = []
+    for item in itemList:
+        item["broken_url"] = (item["broken_url"].encode('ascii', 'ignore')).decode("utf-8")
+        item["package_title"] = (item["package_title"].encode('ascii', 'ignore')).decode("utf-8")
+        items.append(
+            singleItem.format(
+                package_id=item["package_id"],
+                package_title=item["package_title"],
+                resource_id=item["resource_id"],
+                broken_url=item["broken_url"],
+                site_url=config['ckan.site_url'],
+            ).encode('utf-8')
+        )
+
+    separator = '\n'
+    return messageTemplate.format(amount=len(itemList), items=separator.join(items))
+
+
+subject = "{amount} broken link(s) in your datasets"
+
+
+messageTemplate = """
+You have {amount} broken link(s) in your datasets.
+You can update the link(s) by logging in and navigating to the broken resource.
+
+{items}
+---
+
+Best regards
+
+Avoindata.fi support
+avoindata@vrk.fi
+"""
+
+
+singleItem = """---
+
+Dataset:
+{package_title} ( {site_url}/data/fi/dataset/{package_id} )
+
+Resource:
+{site_url}/data/fi/dataset/{package_id}/resource/{resource_id}
+
+Broken link:
+{broken_url}
+"""

--- a/ckanext/archiver/model.py
+++ b/ckanext/archiver/model.py
@@ -45,6 +45,7 @@ class Status:
             21: 'Chose not to download',
             22: 'Download failure',
             23: 'System error during archival',
+            24: 'Forbidden error',
         }
         self._by_id = dict(not_broken, **broken)
         self._by_id.update(not_sure)

--- a/ckanext/archiver/tasks.py
+++ b/ckanext/archiver/tasks.py
@@ -360,7 +360,6 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
         download_status_id = Status.by_text('Download error')
         try_as_api = True
     except DownloadError, e:
-        log.info('ErrorERRORRERERROROROROROOROR: %s' % e)
         download_status_id = Status.by_text('Download error')
         try_as_api = True
     except ChooseNotToDownload, e:
@@ -377,7 +376,6 @@ def _update_resource(ckan_ini_filepath, resource_id, queue, log):
         return
 
     if not Status.is_ok(download_status_id):
-        log.info('DOWNLOAD STATUS ID: %s' % download_status_id)
         log.info('GET error: %s - %r, %r "%s"',
                  Status.by_id(download_status_id), e, e.args,
                  resource.get('url'))


### PR DESCRIPTION
Added command 'send_broken_link_notification' to mail maintainers about broken links in their datasets.
Added templates for emails.
Added Forbidden error to list of not_sure Statuses.