### PR TITLE
AV-1274: Translate report info in templates

### DIFF
--- a/ckanext/archiver/reports.py
+++ b/ckanext/archiver/reports.py
@@ -238,8 +238,8 @@ def broken_links_option_combinations():
 
 broken_links_report_info = {
     'name': 'broken-links',
-    'title': _('Broken links'),
-    'description': _('Dataset resource URLs that are found to result in errors when resolved.'),
+    'title': 'Broken links',
+    'description': 'Dataset resource URLs that are found to result in errors when resolved.',
     'option_defaults': OrderedDict((('organization', None),
                                     ('include_sub_organizations', False),
                                     )),


### PR DESCRIPTION
- Don't translate strings outside requests